### PR TITLE
Do not stop on missing cache file

### DIFF
--- a/rules/old.go
+++ b/rules/old.go
@@ -28,7 +28,8 @@ func howOld(name string, dep *cfg.Dependency, lock *cfg.Lock, repo vcs.Repo) {
 			}
 			d, err := cache.RepoData(key)
 			if err != nil {
-				msg.Die("Unable to get cached repo data: %s", err)
+				msg.Err("Unable to get cached repo data: %s", err)
+				return
 			}
 			ref = d.DefaultBranch
 		}


### PR DESCRIPTION
Use msg.Err to signal an error instead of dying. Fail fast is often right, but here not usable.
This fixes #4 
